### PR TITLE
add label_colors to valid list

### DIFF
--- a/R/github_issue_contributions.R
+++ b/R/github_issue_contributions.R
@@ -38,6 +38,7 @@ new_tbl_github_issues <- function(url = character(0),
     title,
     type,
     labels,
+    label_colors,
     font_colors,
     created_at,
     updated_at


### PR DESCRIPTION
## Situation

An issue brought up by @tobyhodges noted that the help wanted issues on the main site were all carpentries blue: https://carpentries.org/help-wanted-issues/ 

![screenshot of help wanted page showing all labels blue](https://user-images.githubusercontent.com/3639446/104206815-d8360580-53e4-11eb-9bcd-33672c142e54.png)

## Cause

I dug into this a bit and found that the `label_colors` property was missing from the underlying data in https://feeds.carpentries.org/help_wanted_issues.json

When I ran this script on the glosario repository, I found that while `extract_issue_info()` would code a column for `label_color`, it didn't show up in the resulting table.

## Solution

I added a line to `new_tbl_github_issue()`.