### PR TITLE
make details into an array

### DIFF
--- a/pages/all_members_location.geojson
+++ b/pages/all_members_location.geojson
@@ -19,7 +19,7 @@ permalink: /all_members_by_location.geojson
       },
       "properties": {
         "marker-color": "#2b3990",
-        "details": "{{member.name}}"
+        "details": ["{{member.name}}"]
       }
     }{% unless forloop.last %},{% endunless %}  {% endif %}  {% endfor %}
   ]


### PR DESCRIPTION
Even when it's just one item, `details` needs to be an array to properly build the map on the carpentries.org website.