### PR TITLE
use query 168 for workshop stats

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,8 +14,9 @@ jobs:
       RSPM: "https://packagemanager.rstudio.com/all/__linux__/focal/latest"
       REDASH_KEY_QUERY33: ${{ secrets.REDASH_KEY_QUERY33 }}
       REDASH_KEY_QUERY39: ${{ secrets.REDASH_KEY_QUERY39 }}
-      REDASH_KEY_QUERY184: ${{ secrets.REDASH_KEY_QUERY184 }}
       REDASH_KEY_QUERY157: ${{ secrets.REDASH_KEY_QUERY157 }}
+      REDASH_KEY_QUERY168: ${{ secrets.REDASH_KEY_QUERY168 }}
+      REDASH_KEY_QUERY184: ${{ secrets.REDASH_KEY_QUERY184 }}
       REDASH_KEY_QUERY187: ${{ secrets.REDASH_KEY_QUERY187 }}
       REDASH_KEY_QUERY295: ${{ secrets.REDASH_KEY_QUERY295 }}
       REDASH_KEY_QUERY400: ${{ secrets.REDASH_KEY_QUERY400 }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Install Python modules
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install --user numpy scipy matplotlib ipython jupyter pandas plotly requests
+          python3 -m pip install --user numpy scipy matplotlib ipython jupyter pandas plotly requests pycountry
 
       ### Finally --------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ everything:
 ## workshops  : workshop JSON feeds from AMY data accessed from redash
 workshops :
 	./bin/make_workshop_feeds.sh _data/
+	python3 python/workshop_stats.py
 
 ## members    : feeds with information about our community members
 members:
@@ -38,7 +39,6 @@ plots:
 	python3 python/curriculum_teaching_frequency.py
 	python3 python/instructor_teaching_frequency.py
 	python3 python/checkout_steps.py
-	python3 python/workshop_stats.py 
 
 
 ## incubator  : carpentries-incubator lesson feed

--- a/python/workshop_stats.py
+++ b/python/workshop_stats.py
@@ -38,16 +38,16 @@ def get_lesson_program(tags):
 
 def admin_name(row):
     """Sets administrator as self organized, centrally organized, instructor training"""
-    if row['administrator_id'] in (302, 642, 173):
+    if row['administrator_id'] in ("302", "642", "173"):
         return 'CO'
-    elif row['administrator_id'] == 717:
+    elif row['administrator_id'] == "717":
         return 'IT'
     else:
         return 'SO'
 
 # Read data from redash query for workshops with administrator
-api_key384 = os.environ['REDASH_KEY_QUERY384']
-data = pd.read_csv("http://redash.carpentries.org/api/queries/384/results.csv?api_key=" + api_key384, keep_default_na=False)
+api_key168 = os.environ['REDASH_KEY_QUERY168']
+data = pd.read_csv("http://redash.carpentries.org/api/queries/168/results.csv?api_key=" + api_key168, keep_default_na=False)
 
 # Set full country name
 data['country_name'] = data['country'].apply(lambda x: get_country_name(x))


### PR DESCRIPTION
1. Query 168 is being used for the workshop reports app and already included all workshops, so I suggest we also use it for generating these feeds to limit the number of places we get these data from AMY in case the database structure changes.
2. Query 384 did not include workshops for which the admin_id was NULL, so the data type to check whether it's a CO or SO workshop is now a string. I don't know if there is a better practice in python to deal with this situation
3. In the PR, it was mentioned that all workshops needed to be included but Query 384 was filtering on the tag "private-event" and the `public_status = 'public'`. Query 168 includes both of these workshops.