### PR TITLE
use pre-installed R version

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,11 +36,12 @@ jobs:
 
 
       ### Install R ------------------------------------------------------------
-
-      - name: Set up R
-        uses: r-lib/actions/setup-r@master
+      
+      - name: "Set up R"
+        uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
+          install-r: false
 
       - name: Install Pandoc
         uses: r-lib/actions/setup-pandoc@v1


### PR DESCRIPTION
This will prevent timeouts due to the system not being able to find R. We've used this for sandpaper repositories for quite a while now and it works: https://github.com/carpentries/sandpaper/pull/279