### PR TITLE
New env var EXIT_STATUS to signal content failure

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,6 +25,7 @@ jobs:
       REDASH_API_INSTRUCTORS_KEY: ${{ secrets.REDASH_API_INSTRUCTORS_KEY }}
       MAILCHIMP_NEWSLETTER_KEY: ${{ secrets.MAILCHIMP_NEWSLETTER_KEY }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      EXIT_STATUS: 0
 
     defaults:
       run:
@@ -148,7 +149,7 @@ jobs:
       - name: Ping Healthcheck when successful
         if: ${{ success() }}
         run: |
-          curl -fsS --retry 3 ${{ secrets.HEALTHCHECK_URL }}
+          curl -fsS --retry 3 ${{ secrets.HEALTHCHECK_URL }}/${{ env.EXIT_STATUS }}
 
       - name: Ping Healthcheck when failure
         if: ${{ failure() }}

--- a/R/community_lessons.R
+++ b/R/community_lessons.R
@@ -13,10 +13,11 @@ COMMON_TAGS <- c(
 )
 
 check_missing_repo_info <- function(.d, field) {
-  if (any(!nzchar(.d[[field]]))) {
+  has_missing_info <- !nzchar(.d[[field]])
+  if (any(has_missing_info)) {
     paste0(
       "Missing repo ", sQuote(field), " for: \n",
-      paste0("  - ", .d$repo_url[!nzchar(.d[[field]])], collapse = "\n"),
+      paste0("  - ", .d$repo_url[has_missing_info], collapse = "\n"),
       "\n"
     )
   }
@@ -36,7 +37,10 @@ check_repo_info <- function(.d, fields) {
     cli::cli_alert_success("No issues detected!")
   },
   error = function(err) {
-    stop(err$message, call. = FALSE)
+    # Append the status to github env so that we can use it for healthchecks
+    # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+    cat("EXIT_STATUS=1", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+    cat("::warning::", err$message, "\n")
   })
 }
 


### PR DESCRIPTION
This implements a new environment variable `EXIT_STATUS`, which will
signal a failure if the _content_ of one of the feeds is malformed, but
still viable. This is implemented to prevent missing information in the
community lessons feed from causing errors building our entire feeds
structure.

If there are errors in community lessons, we will modify the
`EXIT_STATUS` environment variable to be `1` so that healthchecks pings
an error, even though the build itself will succeed. This means that we
are alerted when things need to be fixed, but we have some grace as to
how they can be fixed.

This will fix #61 