### PR TITLE
define instructor as badge 13

### DIFF
--- a/bin/make_members_feeds.sh
+++ b/bin/make_members_feeds.sh
@@ -33,7 +33,7 @@ curl "$REDASH_API_INSTRUCTORS" |
    .is_trainer_inactive = contains({badges: "11"}) |
    .is_mentor = contains({badges: "8"}) |
    .is_mentee = contains({badges: "9"}) |
-   .is_instructor = .is_swc_instructor or .is_dc_instructor or .is_lc_instructor
+   .is_instructor = contains({badges: "13"})
    )' > /tmp/badged_people_raw.json
 
 ## Make sure the file was successfully downloaded


### PR DESCRIPTION
Rather than is dc/lc/swc instructor, this defines "is_instructor" as having badge 13.  Removing the lesson program specific badges from the feeds will be addressed in another PR.