### PR TITLE
remove python feeds until we fix instructor badges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ memberships:
 plots:
 	R -q -e "source('R/workshop_summary.R')"
 	python3 python/lesson_contributor_count.py
-	python3 python/instructor_training_completion_rates.py
-	python3 python/instructor_training_seat_usage.py
-	python3 python/curriculum_teaching_frequency.py
-	python3 python/instructor_teaching_frequency.py
+	# python3 python/instructor_training_completion_rates.py
+	# python3 python/instructor_training_seat_usage.py
+	# python3 python/curriculum_teaching_frequency.py
+	# python3 python/instructor_teaching_frequency.py
 	python3 python/checkout_steps.py
 	python3 python/membership_trends.py
 


### PR DESCRIPTION
Some python feeds depend on the single badge.  I'm removing them all for now (as a quick and easy stopgap).  Will add them back in once I fix the underlying queries.  
This will allow other builds (like profiles on our website) to succeed. 