### PR TITLE
Revert "temporarily remove make_incubator"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ everything:
 	@make amy_curricula
 	@make newsletter
 	@make plots
+	@make incubator
 	@make help-wanted
 	@make lessons
 	@make memberships


### PR DESCRIPTION
This reverts commit e66363b0f5f121bb10577067a4523147537ccc70.

@tobyhodges found and fixed the problem:

> I think I found and fixed the problem. Someone had added another life cycle stage tag to their lesson repository in the Incubator, but had not removed the old stage tag, and the script was failing because two different life cycle stages were present and it didn’t know how to deal with that. If I can figure out how to edit the script, I will open a PR to update it so that the later life cycle stage is chosen in cases like this (i.e. stable>beta>alpha>pre-alpha)

The API limit exceeded warning is due to us making too many GitHub API requests within an hour, but that's a separate issue. 
