### PR TITLE
temporarily remove curr feed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ help-wanted:
 
 ## lessons    : data feed for the repository information for all "official" lessons
 lessons:
-	R -q -e "source('R/curriculum_feed.R')"
+	# R -q -e "source('R/curriculum_feed.R')"
 
 ## site       : build files but do not run a server.
 ## some files created from the Redash query need to be copied to the


### PR DESCRIPTION
Temporarily remove `curriculum_feed.R` to bypass [this GH actions error](https://github.com/carpentries/feeds.carpentries.org/actions/runs/4811906359/jobs/8566488757)
