### PR TITLE
fix gh actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -107,15 +107,20 @@ jobs:
       ### Finally --------------------------------------------------------------
 
       - name: Make workshops
-        run: make workshops
+        run: |
+          make workshops || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping workshops'
       - name: Make members
-        run: make members
+        run: |          
+          make members || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping members'
       - name: Make amy_curricula
-        run: make amy_curricula
+        run: | 
+          make amy_curricula || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping curricula'
       - name: Make newsletter
-        run: make newsletter
+        run: |
+          make newsletter || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping newsletter'
       - name: Make plots
-        run: make plots
+        run: |
+          make plots || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping plots'
       - name: Make incubator
         run: |
           make incubator || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping incubator'
@@ -126,7 +131,8 @@ jobs:
         run: |
           make lessons || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping lessons feed'
       - name: Make memberships
-        run: make memberships
+        run: |
+          make memberships || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping memberships'
       - name: Make site
         run: make site
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -108,31 +108,31 @@ jobs:
 
       - name: Make workshops
         run: |
-          make workshops || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping workshops'
+          make workshops || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping workshops')
       - name: Make members
         run: |          
-          make members || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping members'
+          make members || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping members')
       - name: Make amy_curricula
         run: | 
-          make amy_curricula || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping curricula'
+          make amy_curricula || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping curricula')
       - name: Make newsletter
         run: |
-          make newsletter || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping newsletter'
+          make newsletter || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping newsletter')
       - name: Make plots
         run: |
-          make plots || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping plots'
+          make plots || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping plots')
       - name: Make incubator
         run: |
-          make incubator || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping incubator'
+          make incubator || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping incubator')
       - name: Make help-wanted
         run: |
-          make help-wanted || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping help-wanted issues'
+          make help-wanted || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping help-wanted issues')
       - name: Make lessons
         run: |
-          make lessons || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping lessons feed'
+          make lessons || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping lessons feed')
       - name: Make memberships
         run: |
-          make memberships || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping memberships'
+          make memberships || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping memberships')
       - name: Make site
         run: make site
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -120,9 +120,11 @@ jobs:
         run: |
           make incubator || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping incubator'
       - name: Make help-wanted
-        run: make help-wanted
+        run: |
+          make help-wanted || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping help-wanted issues'
       - name: Make lessons
-        run: make lessons
+        run: |
+          make lessons || echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping lessons feed'
       - name: Make memberships
         run: make memberships
       - name: Make site

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ incubator:
 
 ## help-wanted: list of issues that have the label "help wanted"
 help-wanted:
-	# R -q -e "source('R/help_wanted_issues.R')"
+	R -q -e "source('R/help_wanted_issues.R')"
 
 ## lessons    : data feed for the repository information for all "official" lessons
 lessons:
-	# R -q -e "source('R/curriculum_feed.R')"
+	R -q -e "source('R/curriculum_feed.R')"
 
 ## site       : build files but do not run a server.
 ## some files created from the Redash query need to be copied to the

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,6 +62,7 @@ get_list_repos <- function(org, ignore_archived = FALSE,
   res  <- gh::gh(
     "GET /orgs/:org/repos",
     org = org,
+    per_page = 100,
     .limit = Inf,
     .send_headers = c(
       "If-Modified-Since" = six_hours_ago()

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,10 +2,28 @@ library(gh)
 library(jsonlite)
 library(purrr)
 
+#' Create a fallback pipe 
+#' 
+#' @param x an R object
+#' @param y an R object to use if x is missing in some fashion
+#'
+#' @examples
+#' "hello there" %<<% "goodbye" # says hello
+#' sleep %<<% "no sleep data" # prints the sleep data set
+#' 
+#' # examples when this is useful: missing data
+#' "" %<<% "missing data"
+#' NULL %<<% "missing data"
+#' character(0) %<<% "missing data" 
+#' c(NA, NA) %<<% "missing data"
 `%<<%` <- function(x, y) {
-  if (identical(length(x), 0L)) return(y)
-  if (is.null(x) || identical(x, "") ||
-        is.na(x)) return(y)
+  if (identical(length(x), 0L)) {
+    return(y)
+  }
+  all_missing <- is.null(x) || identical(x, "") || all(is.na(x))
+  if (all_missing) {
+    return(y)
+  }
   x
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,30 +59,31 @@ check_rate_limit <- function() {
 get_list_repos <- function(org, ignore_archived = FALSE,
                            ignore_pattern = NULL, ...) {
 
-  init_res  <- gh::gh(
+  res  <- gh::gh(
     "GET /orgs/:org/repos",
     org = org,
+    .limit = Inf,
     .send_headers = c(
       "If-Modified-Since" = six_hours_ago()
     )
   )
-  res <- list()
-  test <- TRUE
-  i <- 1
+  # res <- list()
+  # test <- TRUE
+  # i <- 1
 
-  while (test) {
-    message("Getting page: ", i, " for ", sQuote(org))
-    res <- append(res, init_res)
+  # while (test) {
+  #   message("Getting page: ", i, " for ", sQuote(org))
+  #   res <- append(res, init_res)
 
-    init_res <- tryCatch({
-      gh::gh_next(init_res)
-    },
-    error = function(e) {
-      test <<- FALSE
-      NULL
-    })
-    i <- i+1
-  }
+  #   init_res <- tryCatch({
+  #     gh::gh_next(init_res)
+  #   },
+  #   error = function(e) {
+  #     test <<- FALSE
+  #     NULL
+  #   })
+  #   i <- i+1
+  # }
 
   res <- purrr::map_df(res, function(.x) {
     list(


### PR DESCRIPTION
This reverts #75 and #76 and provides the fallback as proposed in #73


In the future, if there are failing feeds, use the `||` to shortcut on error
and report an `EXIT_STATUS` > 1 to the healthchecks.


- re-enable help-wanted and lessons in make
- allow help-wanted and lessons to error with status 2
