### PR TITLE
workflow_dispatch on to allow manual run of action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 */6 * * *'
-  workflow_dispatch: on 
+  workflow_dispatch:
 
 jobs:
   build-feeds:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
   schedule:
     - cron: '0 */6 * * *'
+  workflow_dispatch: on 
 
 jobs:
   build-feeds:


### PR DESCRIPTION
In addition to having scheduled actions, I would like us to have the ability to manually run an action (so we don't have to wait for the next scheduled run if we fix a bug or make a change in between).  According to the instructions on how to [manually run a workflow](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow),  it says [workflow_dispatch must be on](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).  I would like to have someone who knows more about GH Actions than me to review this and be sure it won't cause a conflict with the scheduled runs.
Tagging @zkamvar  or @froggleston  or @elichad 