### PR TITLE
remove github context reporter

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,9 +36,6 @@ jobs:
         shell: bash
 
     steps:
-      - name: show github context
-        run: echo '${{ toJSON(github) }}'
-
       - name: checkout the Repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
For some reason, it's being frustrating and not behaving. Likely because we did not put a value for `workflow_dispatch`, which should be _fine_ according to the docs, but GitHub's gonna GitHub `¯\_(ツ)_/¯`