### PR TITLE
Reorganize files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# Ignore generated feeds and plots
+# as they do not get stored in the repo
+# and clutter the local build 
 _data/*.yml
+_data/*.json
+_data/*.csv
+plot_*.*
+
 _site
 .sass-cache
 .jekyll-metadata

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ lessons:
 site :
 	bundle exec jekyll build
 	find _data -name '*.json' -exec cp {} _site/ \;
+	find images -iregex ".*.\(svg\|html\|png\)" -exec cp {} _site/ \;
 	./bin/make_index.sh
 
 ## install    : install missing Ruby gems using bundle.

--- a/R/workshop_summary.R
+++ b/R/workshop_summary.R
@@ -69,7 +69,7 @@ prepare_workshops_through_time <- function(wksp_data) {
   summary_through_time
 }
 
-workshops_through_time <- function(wksp_data, outfile = "./plot_workshops_through_time.html") {
+workshops_through_time <- function(wksp_data, outfile = "images/plot_workshops_through_time.html") {
   check_export_dir(outfile)
 
   summary_through_time <- prepare_workshops_through_time(wksp_data)
@@ -91,7 +91,7 @@ workshops_through_time <- function(wksp_data, outfile = "./plot_workshops_throug
   outfile
 }
 
-workshops_by_year <- function(wksp_data, outfile = "./plot_workshops_by_year.html") {
+workshops_by_year <- function(wksp_data, outfile = "images/plot_workshops_by_year.html") {
   check_export_dir(outfile)
 
   summary_per_year <- prepare_workshops_through_time(wksp_data) %>%
@@ -121,7 +121,7 @@ workshops_by_year <- function(wksp_data, outfile = "./plot_workshops_by_year.htm
   outfile
 }
 
-workshops_map <- function(wksp_data, outfile = "./plot_workshops_map.svg") {
+workshops_map <- function(wksp_data, outfile = "images/plot_workshops_map.svg") {
   check_export_dir(outfile)
 
   wksp_data <- wksp_data %>%

--- a/python/curriculum_teaching_frequency.py
+++ b/python/curriculum_teaching_frequency.py
@@ -66,6 +66,6 @@ layout = dict(title= title_text + ': 2019',
 fig = go.Figure(data=data, layout=layout)
 
 curr_group.to_csv('_data/curriculum_teaching_frequency.csv')
-plotly.offline.plot(fig, filename='./curriculum_teaching_frequency.html', auto_open=False)
+plotly.offline.plot(fig, filename='images/curriculum_teaching_frequency.html', auto_open=False)
 
 

--- a/python/instructor_teaching_frequency.py
+++ b/python/instructor_teaching_frequency.py
@@ -54,6 +54,6 @@ for p in ax.patches:
 plt.tight_layout()  # Keeps labels on edges from getting cut off
 
 # Save outputs as png image and json data
-plt.savefig('./plot_instructor_teaching_frequency.svg')
+plt.savefig('images/plot_instructor_teaching_frequency.svg')
 with open('_data/instructor_teaching_frequency.json', 'w') as fp:
     json.dump(teaching_frequency_json_data, fp)

--- a/python/instructor_training_completion_rates.py
+++ b/python/instructor_training_completion_rates.py
@@ -68,7 +68,7 @@ for p in ax.patches:
 plt.xticks(rotation='horizontal')
 
 # Save plot to image file
-plt.savefig('./plot_checkout_completion_rates.svg')
+plt.savefig('images/plot_checkout_completion_rates.svg')
 
 # Save dataframe to json
 completion_rates.to_json('_data/checkout_completion_rates.json')

--- a/python/instructor_training_seat_usage.py
+++ b/python/instructor_training_seat_usage.py
@@ -128,4 +128,4 @@ fig = go.Figure(data=data, layout=layout)
 
 
 all_events_df.to_csv('_data/IT_seat_usage.csv')
-plotly.offline.plot(fig, filename='./plot_IT_seat_usage.html', auto_open=False)
+plotly.offline.plot(fig, filename='images/plot_IT_seat_usage.html', auto_open=False)

--- a/python/membership_trends.py
+++ b/python/membership_trends.py
@@ -73,7 +73,7 @@ ax.set_xticklabels(eol, ha="right", fontsize = 14, rotation=45, rotation_mode='a
 ax.legend(['Member count', '6 Month Moving Average'], fontsize = 16)
 
 # Save plot image and json
-plt.savefig('./plot_membership_trends.svg')
+plt.savefig('images/plot_membership_trends.svg')
 member_count_by_month_df['start_month'] = member_count_by_month_df['start_month'].dt.strftime('%Y-%m-%d')
 member_count_by_month_df.to_json('_data/membership_trends.json')
 

--- a/python/membership_trends.py
+++ b/python/membership_trends.py
@@ -75,6 +75,6 @@ ax.legend(['Member count', '6 Month Moving Average'], fontsize = 16)
 # Save plot image and json
 plt.savefig('./plot_membership_trends.svg')
 member_count_by_month_df['start_month'] = member_count_by_month_df['start_month'].dt.strftime('%Y-%m-%d')
-member_count_by_month_df.to_json('membership_trends.json')
+member_count_by_month_df.to_json('_data/membership_trends.json')
 
 


### PR DESCRIPTION
This PR does the following:

* Fixes a typo that kept a json feed from ending up in `_data` folder
* Set up `.gitignore` to ignore generated outputs
* Update R and Python scripts to send all plots to `images` folder so as to not clutter root
* Update Makefile to copy from `images` folder just as it does from `_data` folder
