### PR TITLE
Add template tag

### DIFF
--- a/R/curriculum_feed.R
+++ b/R/curriculum_feed.R
@@ -7,9 +7,22 @@
 ### github topic have the appropriate other topics (at least for life cycle and
 ### human languages).
 
+# NOTE:
+#
+# If you find yourself here wondering why the lesson feed has failed yet again,
+# remember that this works on GitHub topic tags, which are not part of the git
+# repository, but specific to GitHub. 
+#
+# --- Zhian (2023-12-14)
+
 source("R/utils.R")
 
-LIFE_CYCLE_TAGS <- c("pre-alpha", "alpha", "beta", "stable", "on-hold")
+# ZNK 2023-12-14: 
+# Adding the "template" tag here so that we can exclude the templates from our
+# official lesson count. This _is_ a new tag and it's not one that's present in
+# the workbench yet. For now, it will allow the feeds to work.
+LIFE_CYCLE_TAGS <- c("pre-alpha", "alpha", "beta", "stable", "on-hold", 
+  "template")
 HUMAN_LANGUAGE <- c("english", "spanish")
 
 GITHUB_ORGS <- c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,7 +28,7 @@ library(purrr)
 }
 
 use_pat <- function() {
-  if (Sys.getenv("GITHUB_PAT") != "" || Sys.getenv("GITHUB_TOKEN") != "") {
+  if (gh::gh_token() != "" || Sys.getenv("GITHUB_PAT") != "" || Sys.getenv("GITHUB_TOKEN") != "") {
     cli::cli_alert_success("Using GitHub token!")
   } else {
     cli::cli_alert_danger("No GitHub token detected.")


### PR DESCRIPTION
The [lesson feed builds are failing again](https://github.com/carpentries/feeds.carpentries.org/actions/runs/7211012889/job/19645441814#step:22:53):

```
No tag found among (pre-alpha, alpha, beta, stable, on-hold) for repo: carpentries/workbench-template-rmd
```

This is a multiple sources of truth problem. The script is searching the GitHub tags for the life cycle. The issue arose when Toby removed the "alpha" tag from the template repo description tags: https://github.com/carpentries/workbench-template-md/issues/36#issuecomment-1851984643 at the request of Aleks who (rightfully) pointed out that it was confusing to have the template labelled as "alpha" if it was ready for use (see https://github.com/carpentries/workbench-template-md/issues/36).

I have implemented a fix by adding a "template" tag so that a lesson template can will have a `"life_cycle" : "template"` tag. This has the advantage of allowing us to better label the template _and_ treat it as a special type of lesson in our feeds down the road. 