### PR TITLE
add website_stats feed to build action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Make memberships
         run: |
           make memberships || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping memberships')
+      - name: Make website_stats
+        run: |
+          make website_stats || (echo "EXIT_STATUS=2" >> $GITHUB_ENV && echo 'an error occured; skipping website_stats')
       - name: Make site
         run: make site
 


### PR DESCRIPTION
We had updated the action to build the site to individually run each `make` command so that an error would trigger but the rest of the actions would continue.  The new `website_stats` feed needs to be added to this. 